### PR TITLE
feat: Refactor config to use accessors

### DIFF
--- a/src/shared/config/Config.cpp
+++ b/src/shared/config/Config.cpp
@@ -37,7 +37,6 @@ std::vector< shm::Result< void > > shm::Config::SaveDirtyConfigs()
         auto pending_result = cfg_obj->m_impl->ApplyPendingUpdate();
         if ( !pending_result.has_value() )
         {
-            auto msg = pending_result.error().message();
             results.emplace_back( pending_result );
             continue;
         }

--- a/src/shared/config/Config.cpp
+++ b/src/shared/config/Config.cpp
@@ -6,7 +6,8 @@
 
 shm::Config::~Config()
 {
-    SaveDirtyConfigs();
+    // TODO: guard this behind a feature flag
+    //SaveDirtyConfigs();
 }
 
 shm::Config::Config( std::string_view log_root_dir )
@@ -25,8 +26,9 @@ shm::Result< void > shm::Config::IsDirectoryCreated() const
     return {};
 }
 
-size_t shm::Config::SaveDirtyConfigs()
+std::vector< shm::Result< void > > shm::Config::SaveDirtyConfigs()
 {
+    std::vector< shm::Result< void > > results;
     for ( auto & cfg_obj : m_configs )
     {
         if ( !cfg_obj )
@@ -34,17 +36,15 @@ size_t shm::Config::SaveDirtyConfigs()
 
         auto pending_result = cfg_obj->m_impl->ApplyPendingUpdate();
         if ( !pending_result.has_value() )
-            continue; // Optional: log error
-        // std::string json;
-        // auto res = cfg_obj->m_impl->SaveToJson( json );
-        // if ( !res.has_value() )
-        //     continue; // Optional: log error
-        //
-        // const auto path =
-        //     fmt::format( "{}{}.json", m_log_root_dir, cfg_obj->m_impl->GetConfigFileName() );
-        //  shm::fs::WriteFileFromString( path, json );
+        {
+            auto msg = pending_result.error().message();
+            results.emplace_back( pending_result );
+            continue;
+        }
+
+        results.emplace_back( shm::Result< void >{} );
     }
-    return {};
+    return results;
 }
 
 /** CONFIG OBJECT **/


### PR DESCRIPTION
Because config might be accessed from a thread in mutable form, the pending update and consumption of an update is guarded with a mutex. We should access the accessor with const modifier to get the version that does not modify to prevent locking. Locking happens at fetch and destruction of accessor class

Make sure config does not segfault if we request a non-existent config we simply return a pointer to static object (that is not part of config and will not synchronize)

Add config tests and make sure they pass